### PR TITLE
some bugs in convert.py?

### DIFF
--- a/e2e-challenge/input/convert.py
+++ b/e2e-challenge/input/convert.py
@@ -12,13 +12,14 @@ import re
 import argparse
 import unicodecsv as csv
 import codecs
-
+import os, sys
+sys.path.insert(0, os.path.abspath('../../'))
 from tgen.data import DA
 from tgen.delex import delex_sent
 from tgen.futil import tokenize
 
 from tgen.debug import exc_info_hook
-import sys
+
 # Start IPdb on error in interactive mode
 sys.excepthook = exc_info_hook
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 regex
+unicodecsv
 enum34
 numpy
 rpyc


### PR DESCRIPTION
Hello, me again.
When I was testing the script, I found that you may have forgotten to adjust the path, as what you did in other experiments.
Besides, after re-installing modules with requirements.txt, unicodecsv is still missing, so I guess it should also be included.