### PR TITLE
added fix for exception handling syntax

### DIFF
--- a/tgen/externals/seq2seq.py
+++ b/tgen/externals/seq2seq.py
@@ -35,9 +35,10 @@ from tensorflow.contrib.rnn import EmbeddingWrapper, RNNCell, OutputProjectionWr
 try:  # TF 1.0.1
     from tensorflow.contrib.rnn.python.ops.rnn_cell import _linear as linear
 except ImportError: # TF 1.4.1
-    from tensorflow.python.ops.rnn_cell_impl import _linear as linear
-except ImportError: # TF 1.6.0
-    from tensorflow.contrib.rnn.python.ops.core_rnn_cell import _linear as linear
+    try:
+        from tensorflow.python.ops.rnn_cell_impl import _linear as linear
+    except ImportError: # TF 1.6.0
+        from tensorflow.contrib.rnn.python.ops.core_rnn_cell import _linear as linear
 
 
 def rnn(cell, inputs, initial_state=None, dtype=None,


### PR DESCRIPTION
We need an explicit try-except in tgen/externals/seq2seq.py to prevent errors.

Without the explicit try-except, the line `from tensorflow.python.ops.rnn_cell_impl import _linear as linear`  will raise the ImportError without catching it.