### PR TITLE
added check to ensure valid save path for newer versions of Tensorflow

### DIFF
--- a/run_tgen.py
+++ b/run_tgen.py
@@ -255,6 +255,9 @@ def seq2seq_train(args):
 
     args = ap.parse_args(args)
 
+    if not os.path.dirname(args.seq2seq_model_file):
+        raise ValueError("seq2seq_model_file should be an absolute or relative path, not a bare filename")
+
     if args.debug_logfile:
         set_debug_stream(file_stream(args.debug_logfile, mode='w'))
     if args.random_seed:

--- a/tgen/delex.py
+++ b/tgen/delex.py
@@ -156,12 +156,14 @@ def delex_sent(da, conc, abst_slots, use_slot_names=True, delex_slot_names=False
     abst_da = DA()
     toks_mask = [True] * len(toks)
 
+    abst_da_order = []
     # find all values in the sentence, building the abstracted DA along the way
     # search first for longer values (so that substrings don't block them)
     for dai in sorted(da,
                       key=lambda dai: len(dai.value) if dai.value is not None else 0,
                       reverse=True):
         # first, create the 'abstracted' DAI as the copy of the current DAI
+        abst_da_order.append(da.find(dai))
         abst_da.append(DAI(dai.da_type, dai.slot, dai.value))
         if dai.value is None:
             continue
@@ -212,4 +214,6 @@ def delex_sent(da, conc, abst_slots, use_slot_names=True, delex_slot_names=False
         abst.end = abst.start + 1
         shift += shift_add
 
-    return ' '.join(toks) if return_string else toks, abst_da, absts
+    abst_da_original_order = [abst_da[i] for i in abst_da_order]
+
+    return ' '.join(toks) if return_string else toks, abst_da_original_order, absts

--- a/tgen/delex.py
+++ b/tgen/delex.py
@@ -163,7 +163,7 @@ def delex_sent(da, conc, abst_slots, use_slot_names=True, delex_slot_names=False
                       key=lambda dai: len(dai.value) if dai.value is not None else 0,
                       reverse=True):
         # first, create the 'abstracted' DAI as the copy of the current DAI
-        abst_da_order.append(da.dais.find(dai))
+        abst_da_order.append(da.dais.index(dai))
         abst_da.append(DAI(dai.da_type, dai.slot, dai.value))
         if dai.value is None:
             continue

--- a/tgen/delex.py
+++ b/tgen/delex.py
@@ -163,7 +163,7 @@ def delex_sent(da, conc, abst_slots, use_slot_names=True, delex_slot_names=False
                       key=lambda dai: len(dai.value) if dai.value is not None else 0,
                       reverse=True):
         # first, create the 'abstracted' DAI as the copy of the current DAI
-        abst_da_order.append(da.find(dai))
+        abst_da_order.append(da.dais.find(dai))
         abst_da.append(DAI(dai.da_type, dai.slot, dai.value))
         if dai.value is None:
             continue
@@ -214,6 +214,6 @@ def delex_sent(da, conc, abst_slots, use_slot_names=True, delex_slot_names=False
         abst.end = abst.start + 1
         shift += shift_add
 
-    abst_da_original_order = [abst_da[i] for i in abst_da_order]
+    abst_da.dais = [abst_da[i] for i in abst_da_order]
 
-    return ' '.join(toks) if return_string else toks, abst_da_original_order, absts
+    return ' '.join(toks) if return_string else toks, abst_da, absts

--- a/tgen/externals/seq2seq.py
+++ b/tgen/externals/seq2seq.py
@@ -35,9 +35,10 @@ from tensorflow.contrib.rnn import EmbeddingWrapper, RNNCell, OutputProjectionWr
 try:  # TF 1.0.1
     from tensorflow.contrib.rnn.python.ops.rnn_cell import _linear as linear
 except ImportError: # TF 1.4.1
-    from tensorflow.python.ops.rnn_cell_impl import _linear as linear
-except ImportError: # TF 1.6.0
-    from tensorflow.contrib.rnn.python.ops.core_rnn_cell import _linear as linear
+    try:
+        from tensorflow.python.ops.rnn_cell_impl import _linear as linear
+    except ImportError: # TF 1.6.0
+        from tensorflow.contrib.rnn.python.ops.core_rnn_cell import _linear as linear
 
 
 def rnn(cell, inputs, initial_state=None, dtype=None,


### PR DESCRIPTION
Sometime between 0.10 and 1.7 there was a change where `tensorflow.python.training.saver` uses `os.path.dirname()` to check that the directory where the model is to be saved exists. Unfortunately, this requires that the save path be a full relative or absolute path rather than being a bare filename.

For example, in the `README.md` for e2e-challenge, the filename `model.pickle.gz` needs to be specified as `./model.pickle.gz` to avoid raising this exception.

I added a simple error check in `run_tgen.py` to call this to users' attention as soon as they attempt to launch a model, rather than letting it train for 24 hours and then fail to save ;)

This shouldn't have any negative effects for users running on older versions of TensorFlow, as far as I can tell.