### PR TITLE
no val lexicalizer fix

### DIFF
--- a/tgen/seq2seq.py
+++ b/tgen/seq2seq.py
@@ -448,6 +448,8 @@ class Seq2SeqGen(Seq2SeqBase, TFModel):
         # ... or save part of the training data for validation:
         elif self.validation_size > 0:
             valid_trees_for_lexic, valid_idxs = self._cut_valid_data()  # will set train_trees, valid_trees, train_das, valid_das
+        else:
+            valid_trees_for_lexic, valid_idxs = None, None
 
         if self.validation_use_all_refs:  # try to use multiple references (not in lexicalizer)
             self._regroup_valid_refs()


### PR DESCRIPTION
When no validation data is given (i.e. `validation_size` in a given `config.yaml` is set to `0`) `valid_trees_for_lexic` is not set, and should not be passed to the [lexicalizer](https://github.com/UFAL-DSG/tgen/blob/master/tgen/seq2seq.py#L488). For some reason, the default `None` [here](https://github.com/UFAL-DSG/tgen/blob/master/tgen/lexicalize.py#L495) is currently ignored, resulting in an `IndexError` further down `tfcassif.py`. If [this](https://github.com/UFAL-DSG/tgen/blob/master/tgen/seq2seq.py#L449) `if` clause includes an `else` to set this to `None` (as per the pull request), the error is fixed. This can be reproduced running the e2e config (with val parts set to `0`, `False`, etc.) on the bagel data.